### PR TITLE
Update variables and values to allow for more robust config

### DIFF
--- a/read_replica.tf
+++ b/read_replica.tf
@@ -36,7 +36,6 @@ resource "google_sql_database_instance" "replicas" {
   settings {
     tier              = lookup(each.value, "tier", var.tier)
     activation_policy = "ALWAYS"
-    pricing_plan      = lookup(each.value, "pricing_plan", var.pricing_plan)
 
     dynamic "ip_configuration" {
       for_each = [lookup(each.value, "ip_configuration", var.ip_configuration)]
@@ -67,7 +66,7 @@ resource "google_sql_database_instance" "replicas" {
     disk_autoresize = lookup(each.value, "disk_autoresize", var.disk_autoresize)
     disk_size       = var.disk_autoresize ? null : lookup(each.value, "disk_size", var.disk_size)
     disk_type       = lookup(each.value, "disk_type", var.disk_type)
-    pricing_plan    = "PER_USE"
+    pricing_plan    = lookup(each.value, "pricing_plan", var.pricing_plan)
     user_labels     = lookup(each.value, "user_labels", var.user_labels)
 
     dynamic "database_flags" {

--- a/read_replica.tf
+++ b/read_replica.tf
@@ -36,6 +36,7 @@ resource "google_sql_database_instance" "replicas" {
   settings {
     tier              = lookup(each.value, "tier", var.tier)
     activation_policy = "ALWAYS"
+    pricing_plan      = lookup(each.value, "pricing_plan", var.pricing_plan)
 
     dynamic "ip_configuration" {
       for_each = [lookup(each.value, "ip_configuration", var.ip_configuration)]

--- a/variables.tf
+++ b/variables.tf
@@ -164,8 +164,18 @@ variable "insights_config" {
     record_client_address   = bool
   }
   EOT
-  type        = map(any)
-  default     = {}
+  type = object({
+    query_insights_enabled  = bool
+    query_string_length     = number
+    record_application_tags = bool
+    record_client_address   = bool
+  })
+  default = {
+    query_insights_enabled  = true
+    query_string_length     = 1024
+    record_application_tags = false
+    record_client_address   = false
+  }
 }
 
 variable "ip_configuration" {


### PR DESCRIPTION
- Updates read replica config to allow for dynamic `pricing_plan` config versus a hard coded one
- Updates the query insights config to allow for all values