### PR TITLE
Test default for edition variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "tier" {
 variable "edition" {
   description = "The edition of the master instance"
   type        = string
-  default     = "ENTERPRISE"
+  default     = null
 }
 
 variable "zone" {

--- a/versions.tf
+++ b/versions.tf
@@ -27,7 +27,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.60"
+      version = ">= 4.0"
     }
   }
 


### PR DESCRIPTION
Resolves edition cycle for database - only needed for new databases.  Google provider 5.0 also resolves this.